### PR TITLE
Add github action to update lockfile on dependabot updates

### DIFF
--- a/.github/workflows/update_lockfile.yml
+++ b/.github/workflows/update_lockfile.yml
@@ -1,0 +1,27 @@
+# https://github.com/dependabot/dependabot-core/issues/1736
+# from https://gist.github.com/Purpzie/8ed86ae38c73f440881bbee0523a324b
+
+name: Dependabot
+on: pull_request_target
+permissions: read-all
+jobs:
+  update-lockfile:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - uses: pnpm/action-setup@v2
+        with:
+          version: latest
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+      - run: pnpm i --lockfile-only
+      - run: |
+          git config --global user.name github-actions[bot]
+          git config --global user.email github-actions[bot]@users.noreply.github.com
+          git add pnpm-lock.yaml
+          git commit -m "Update pnpm-lock.yaml"
+          git push


### PR DESCRIPTION
It looks like dependabot does not support pnpm yet (cf. [this issue](https://github.com/dependabot/dependabot-core/issues/1736))

This github action inspired from [this gist](https://gist.github.com/Purpzie/8ed86ae38c73f440881bbee0523a324b) aims to update pnpm.lock file on dependabot dependencies updates